### PR TITLE
Add interactive tooltip to spending overview bar chart

### DIFF
--- a/financetracker/app/(tabs)/home.tsx
+++ b/financetracker/app/(tabs)/home.tsx
@@ -215,6 +215,7 @@ export default function HomeScreen() {
             return {
               label: target.format("MMM"),
               value: spent,
+              hint: target.format("MMMM YYYY"),
             };
           })
         : [];
@@ -485,6 +486,9 @@ export default function HomeScreen() {
               <SpendingBarChart
                 data={overviewPeriod === "month" ? monthlyComparison : periodDailySpending}
                 style={styles.chart}
+                formatValue={(value) =>
+                  formatCurrency(value, currency, { maximumFractionDigits: 0 })
+                }
               />
             )}
           </View>


### PR DESCRIPTION
## Summary
- add interactive tooltip support to the spending overview bar chart
- include formatted values and contextual labels when selecting bars in the overview

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dde526c2f8832795f3d5da58d5e836