### PR TITLE
Improve safe area responsiveness on iPhone screens

### DIFF
--- a/financetracker/app/(tabs)/_layout.tsx
+++ b/financetracker/app/(tabs)/_layout.tsx
@@ -165,7 +165,10 @@ const createStyles = (
       position: "absolute",
       left: 12 + insets.left,
       right: 12 + insets.right,
-      bottom: Math.max(Platform.select({ ios: 26, default: 18 }), insets.bottom + 12),
+      bottom: Platform.select({
+        ios: Math.max(12, insets.bottom * 0.5),
+        default: 18,
+      }),
       alignSelf: "center",
       backgroundColor: theme.colors.surface,
       borderTopWidth: 0,

--- a/financetracker/app/(tabs)/_layout.tsx
+++ b/financetracker/app/(tabs)/_layout.tsx
@@ -159,8 +159,10 @@ const DEFAULT_INSETS: EdgeInsets = { top: 0, bottom: 0, left: 0, right: 0 };
 const createStyles = (
   theme: ReturnType<typeof useAppTheme>,
   insets: EdgeInsets = DEFAULT_INSETS,
-) =>
-  StyleSheet.create({
+) => {
+  const iosInset = Platform.OS === "ios" ? Math.max(insets.bottom - 6, 0) : 0;
+
+  return StyleSheet.create({
     tabBar: {
       position: "absolute",
       left: 12 + insets.left,
@@ -180,8 +182,11 @@ const createStyles = (
       shadowOffset: { width: 0, height: 10 },
       minHeight: Platform.select({ ios: 70, default: 66 }),
       paddingHorizontal: 4,
-      paddingTop: 6,
-      paddingBottom: Platform.select({ ios: 12 + insets.bottom, default: 10 + insets.bottom * 0.6 }),
+      paddingTop: Platform.select({ ios: 10 + iosInset * 0.35, default: 6 }),
+      paddingBottom: Platform.select({
+        ios: 14 + iosInset * 0.65,
+        default: 10 + insets.bottom * 0.6,
+      }),
     },
     tabLabel: {
       fontSize: 10,
@@ -196,7 +201,8 @@ const createStyles = (
       alignItems: "center",
       justifyContent: "center",
       marginHorizontal: 0,
-      paddingVertical: 0,
+      paddingTop: Platform.select({ ios: iosInset * 0.35, default: 0 }),
+      paddingBottom: 0,
       paddingHorizontal: 2,
       minWidth: 0,
     },
@@ -230,3 +236,4 @@ const createStyles = (
       letterSpacing: 0.2,
     },
   });
+};

--- a/financetracker/app/(tabs)/_layout.tsx
+++ b/financetracker/app/(tabs)/_layout.tsx
@@ -3,6 +3,8 @@ import { Animated, Platform, Pressable, StyleSheet, Text, View } from "react-nat
 import { Tabs, useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import type { BottomTabBarButtonProps } from "@react-navigation/bottom-tabs";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import type { EdgeInsets } from "react-native-safe-area-context";
 
 import { useAppTheme } from "../../theme";
 
@@ -65,7 +67,8 @@ function AnimatedTabIcon({ focused, color, size, activeName, inactiveName }: Ani
 
 export default function TabsLayout() {
   const theme = useAppTheme();
-  const styles = useMemo(() => createStyles(theme), [theme]);
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(theme, insets), [theme, insets]);
 
   return (
     <Tabs
@@ -151,13 +154,18 @@ export default function TabsLayout() {
   );
 }
 
-const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
+const DEFAULT_INSETS: EdgeInsets = { top: 0, bottom: 0, left: 0, right: 0 };
+
+const createStyles = (
+  theme: ReturnType<typeof useAppTheme>,
+  insets: EdgeInsets = DEFAULT_INSETS,
+) =>
   StyleSheet.create({
     tabBar: {
       position: "absolute",
-      left: 12,
-      right: 12,
-      bottom: Platform.select({ ios: 26, default: 18 }),
+      left: 12 + insets.left,
+      right: 12 + insets.right,
+      bottom: Math.max(Platform.select({ ios: 26, default: 18 }), insets.bottom + 12),
       alignSelf: "center",
       backgroundColor: theme.colors.surface,
       borderTopWidth: 0,
@@ -167,10 +175,10 @@ const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
       shadowOpacity: Platform.OS === "ios" ? 0.18 : 0.2,
       shadowRadius: 16,
       shadowOffset: { width: 0, height: 10 },
-      height: Platform.select({ ios: 70, default: 66 }),
+      minHeight: Platform.select({ ios: 70, default: 66 }),
       paddingHorizontal: 4,
       paddingTop: 6,
-      paddingBottom: Platform.select({ ios: 16, default: 10 }),
+      paddingBottom: Platform.select({ ios: 12 + insets.bottom, default: 10 + insets.bottom * 0.6 }),
     },
     tabLabel: {
       fontSize: 10,

--- a/financetracker/app/(tabs)/account.tsx
+++ b/financetracker/app/(tabs)/account.tsx
@@ -10,7 +10,7 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 
 import { useAppTheme } from "../../theme";
@@ -39,7 +39,8 @@ export default function AccountScreen() {
   const [goalPeriod, setGoalPeriod] = useState<(typeof goalPeriods)[number]>("month");
   const [goalCategory, setGoalCategory] = useState<string | null>(null);
 
-  const styles = useMemo(() => createStyles(theme), [theme]);
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(theme, insets), [theme, insets]);
 
   useEffect(() => {
     setName(profile.name);
@@ -102,7 +103,11 @@ export default function AccountScreen() {
         behavior={Platform.OS === "ios" ? "padding" : undefined}
         keyboardVerticalOffset={24}
       >
-        <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <ScrollView
+          contentContainerStyle={styles.content}
+          contentInsetAdjustmentBehavior="automatic"
+          showsVerticalScrollIndicator={false}
+        >
           <View style={styles.header}>
             <Text style={styles.title}>Account & preferences</Text>
             <Text style={styles.subtitle}>Personalize how your finance world looks.</Text>
@@ -320,7 +325,10 @@ export default function AccountScreen() {
   );
 }
 
-const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
+const createStyles = (
+  theme: ReturnType<typeof useAppTheme>,
+  insets: ReturnType<typeof useSafeAreaInsets>,
+) =>
   StyleSheet.create({
     safeArea: {
       flex: 1,
@@ -331,7 +339,9 @@ const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
     },
     content: {
       flexGrow: 1,
-      padding: theme.spacing.xl,
+      paddingTop: theme.spacing.xl,
+      paddingHorizontal: theme.spacing.xl,
+      paddingBottom: theme.spacing.xl + insets.bottom,
       gap: theme.spacing.xl,
     },
     header: {

--- a/financetracker/app/(tabs)/home.tsx
+++ b/financetracker/app/(tabs)/home.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import dayjs from "dayjs";
 import { useRouter } from "expo-router";
@@ -80,7 +80,8 @@ export default function HomeScreen() {
   const [topSpendingPeriod, setTopSpendingPeriod] = useState<"week" | "month">("month");
   const [showBalance, setShowBalance] = useState(true);
 
-  const styles = useMemo(() => createStyles(theme), [theme]);
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(theme, insets), [theme, insets]);
 
   useEffect(() => {
     if (overviewPeriod === "week" && overviewChart === "line") {
@@ -368,7 +369,11 @@ export default function HomeScreen() {
 
   return (
     <SafeAreaView style={styles.safeArea}>
-      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        contentContainerStyle={styles.content}
+        contentInsetAdjustmentBehavior="automatic"
+        showsVerticalScrollIndicator={false}
+      >
         <View style={styles.header}>
           <Text style={styles.hello}>Welcome back, {profile.name.split(" ")[0]}</Text>
           <Text style={styles.subtitle}>Here’s a tidy look at your money this month.</Text>
@@ -714,7 +719,10 @@ export default function HomeScreen() {
   );
 }
 
-const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
+const createStyles = (
+  theme: ReturnType<typeof useAppTheme>,
+  insets: ReturnType<typeof useSafeAreaInsets>,
+) =>
   StyleSheet.create({
     safeArea: {
       flex: 1,
@@ -723,7 +731,7 @@ const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
     content: {
       paddingHorizontal: theme.spacing.md,
       paddingTop: theme.spacing.lg,
-      paddingBottom: theme.spacing.xxl + 96,
+      paddingBottom: theme.spacing.xxl + 96 + insets.bottom,
       gap: theme.spacing.lg,
     },
     header: {

--- a/financetracker/app/(tabs)/leaderboard.tsx
+++ b/financetracker/app/(tabs)/leaderboard.tsx
@@ -1,5 +1,6 @@
-import { SafeAreaView } from "react-native-safe-area-context";
+import { useMemo } from "react";
 import { FlatList, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 
 import { useAppTheme } from "../../theme";
@@ -12,7 +13,8 @@ const mockLeaders = [
 
 export default function LeaderboardScreen() {
   const theme = useAppTheme();
-  const styles = createStyles(theme);
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(theme, insets), [theme, insets]);
 
   return (
     <SafeAreaView style={styles.safeArea}>
@@ -44,12 +46,17 @@ export default function LeaderboardScreen() {
   );
 }
 
-const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
+const createStyles = (
+  theme: ReturnType<typeof useAppTheme>,
+  insets: ReturnType<typeof useSafeAreaInsets>,
+) =>
   StyleSheet.create({
     safeArea: {
       flex: 1,
       backgroundColor: theme.colors.background,
-      padding: theme.spacing.xl,
+      paddingTop: theme.spacing.xl,
+      paddingHorizontal: theme.spacing.xl,
+      paddingBottom: theme.spacing.xl + insets.bottom,
     },
     header: {
       gap: theme.spacing.sm,
@@ -62,7 +69,7 @@ const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
       ...theme.typography.subtitle,
     },
     listContent: {
-      paddingBottom: theme.spacing.xxl * 1.5,
+      paddingBottom: theme.spacing.xxl * 1.5 + insets.bottom,
       gap: theme.spacing.lg,
     },
     card: {

--- a/financetracker/app/(tabs)/transactions.tsx
+++ b/financetracker/app/(tabs)/transactions.tsx
@@ -11,7 +11,7 @@ import {
   View,
 } from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import dayjs, { type Dayjs } from "dayjs";
 
@@ -78,7 +78,8 @@ export default function TransactionsScreen() {
   const [showEndPicker, setShowEndPicker] = useState(false);
   const [searchHistory, setSearchHistory] = useState<string[]>([]);
 
-  const styles = useMemo(() => createStyles(theme), [theme]);
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(theme, insets), [theme, insets]);
 
   const toggleCategory = (category: string) => {
     setSelectedCategories((prev) =>
@@ -334,6 +335,7 @@ export default function TransactionsScreen() {
         keyExtractor={(item) => item.id}
         stickySectionHeadersEnabled={false}
         contentContainerStyle={styles.listContent}
+        contentInsetAdjustmentBehavior="automatic"
         ListHeaderComponent={
           <View style={styles.header}>
             <View style={styles.headingBlock}>
@@ -343,11 +345,11 @@ export default function TransactionsScreen() {
               </Text>
             </View>
             <View style={styles.periodTabs}>
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.periodTabsContent}
-              >
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.periodTabsContent}
+            >
                 {periodOptions.map((option) => {
                   const active = option.key === selectedPeriod;
                   return (
@@ -396,11 +398,11 @@ export default function TransactionsScreen() {
             </View>
 
             {hasActiveFilters && (
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.activeFiltersRow}
-              >
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.activeFiltersRow}
+            >
                 {activeFilters.map((filter) => (
                   <Pressable
                     key={filter.key}
@@ -680,6 +682,7 @@ export default function TransactionsScreen() {
               style={styles.filtersSheet}
               contentContainerStyle={styles.filtersSheetContent}
               showsVerticalScrollIndicator={false}
+              contentInsetAdjustmentBehavior="automatic"
             >
               <View style={styles.sheetRow}>
                 <View style={styles.sheetColumn}>
@@ -815,7 +818,10 @@ export default function TransactionsScreen() {
   );
 }
 
-const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
+const createStyles = (
+  theme: ReturnType<typeof useAppTheme>,
+  insets: ReturnType<typeof useSafeAreaInsets>,
+) =>
   StyleSheet.create({
     safeArea: {
       flex: 1,
@@ -824,7 +830,7 @@ const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
     listContent: {
       paddingHorizontal: theme.spacing.lg,
       paddingTop: theme.spacing.lg,
-      paddingBottom: theme.spacing.xl,
+      paddingBottom: theme.spacing.xl + insets.bottom,
       gap: theme.spacing.lg,
     },
     header: {
@@ -949,7 +955,7 @@ const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
       flex: 1,
       backgroundColor: theme.colors.background,
       paddingHorizontal: theme.spacing.lg,
-      paddingBottom: theme.spacing.xl,
+      paddingBottom: theme.spacing.xl + insets.bottom,
       gap: theme.spacing.lg,
     },
     searchModalHeader: {
@@ -1035,7 +1041,7 @@ const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
     },
     filtersSheetContent: {
       gap: theme.spacing.lg,
-      paddingBottom: theme.spacing.xl,
+      paddingBottom: theme.spacing.xl + insets.bottom,
     },
     sheetRow: {
       flexDirection: "row",

--- a/financetracker/app/transactions/new.tsx
+++ b/financetracker/app/transactions/new.tsx
@@ -11,7 +11,7 @@ import {
   View,
 } from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import dayjs from "dayjs";
 import { Ionicons } from "@expo/vector-icons";
@@ -33,7 +33,8 @@ export default function NewTransactionModal() {
   const [date, setDate] = useState(new Date());
   const [showPicker, setShowPicker] = useState(Platform.OS === "ios");
 
-  const styles = useMemo(() => createStyles(theme), [theme]);
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(theme, insets), [theme, insets]);
 
   const handleSubmit = () => {
     const parsedAmount = Number(amount);
@@ -64,7 +65,7 @@ export default function NewTransactionModal() {
       <KeyboardAvoidingView
         style={styles.flex}
         behavior={Platform.OS === "ios" ? "padding" : undefined}
-        keyboardVerticalOffset={32}
+        keyboardVerticalOffset={32 + insets.top}
       >
         <View style={styles.header}>
           <Pressable onPress={() => router.back()} style={styles.closeButton}>
@@ -77,6 +78,7 @@ export default function NewTransactionModal() {
         <ScrollView
           style={styles.flex}
           contentContainerStyle={styles.content}
+          contentInsetAdjustmentBehavior="automatic"
           showsVerticalScrollIndicator={false}
         >
           <View style={styles.toggleRow}>
@@ -176,7 +178,10 @@ export default function NewTransactionModal() {
   );
 }
 
-const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
+const createStyles = (
+  theme: ReturnType<typeof useAppTheme>,
+  insets: ReturnType<typeof useSafeAreaInsets>,
+) =>
   StyleSheet.create({
     safeArea: {
       flex: 1,
@@ -206,7 +211,7 @@ const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
     },
     content: {
       paddingHorizontal: theme.spacing.xl,
-      paddingBottom: theme.spacing.xl,
+      paddingBottom: theme.spacing.xl + insets.bottom,
       gap: theme.spacing.lg,
     },
     toggleRow: {
@@ -279,7 +284,9 @@ const createStyles = (theme: ReturnType<typeof useAppTheme>) =>
     },
     submitButton: {
       ...theme.components.buttonPrimary,
-      margin: theme.spacing.xl,
+      marginTop: theme.spacing.lg,
+      marginHorizontal: theme.spacing.xl,
+      marginBottom: theme.spacing.xl + insets.bottom,
     },
     submitButtonText: {
       ...theme.components.buttonPrimaryText,


### PR DESCRIPTION
## Summary
- adjust the bottom tab bar to respect safe area insets and avoid the iOS home indicator
- add safe-area-aware padding to primary screens and modal flows to keep content visible on all devices
- update scroll containers to use automatic inset adjustment for consistent spacing across screen sizes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddfaaf54c483278bc1b1389a1f5708