### PR TITLE
Handle empty notes and deduplicate transaction photos

### DIFF
--- a/financetracker/app/transactions/[id].tsx
+++ b/financetracker/app/transactions/[id].tsx
@@ -1,0 +1,405 @@
+import { useMemo } from "react";
+import {
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Ionicons } from "@expo/vector-icons";
+import dayjs from "dayjs";
+import { Image } from "expo-image";
+
+import { useAppTheme } from "../../theme";
+import { useFinanceStore } from "../../lib/store";
+
+export default function TransactionDetailsScreen() {
+  const theme = useAppTheme();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(theme, insets), [theme, insets]);
+
+  const { id } = useLocalSearchParams<{ id?: string }>();
+  const transaction = useFinanceStore((state) =>
+    state.transactions.find((item) => item.id === id),
+  );
+  const duplicateTransaction = useFinanceStore((state) => state.duplicateTransaction);
+  const removeTransaction = useFinanceStore((state) => state.removeTransaction);
+
+  if (!transaction) {
+    return (
+      <SafeAreaView style={styles.safeArea}>
+        <View style={[styles.flex, styles.emptyState]}>
+          <Ionicons name="alert-circle" size={48} color={theme.colors.textMuted} />
+          <Text style={styles.emptyTitle}>Transaction not found</Text>
+          <Pressable style={styles.primaryButton} onPress={() => router.back()}>
+            <Text style={styles.primaryButtonText}>Go back</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const isIncome = transaction.type === "income";
+  const amountSign = isIncome ? "+" : "−";
+  const participants = transaction.participants ?? [];
+  const photos = transaction.photos ?? [];
+  const noteDisplay = transaction.note.trim() || "—";
+
+  const handleDuplicate = () => {
+    duplicateTransaction(transaction.id);
+    Alert.alert("Duplicated", "A copy was added to your transactions.");
+  };
+
+  const handleDelete = () => {
+    Alert.alert("Delete transaction", "This action cannot be undone.", [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: () => {
+          removeTransaction(transaction.id);
+          router.back();
+        },
+      },
+    ]);
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <Pressable style={styles.headerButton} onPress={() => router.back()}>
+            <Ionicons name="chevron-back" size={22} color={theme.colors.text} />
+          </Pressable>
+          <Text style={styles.title}>Transaction details</Text>
+          <Pressable
+            style={styles.headerButton}
+            onPress={() => router.push({ pathname: "/transactions/new", params: { transactionId: transaction.id } })}
+          >
+            <Ionicons name="pencil" size={20} color={theme.colors.text} />
+          </Pressable>
+        </View>
+
+        <View style={[theme.components.surface, styles.summaryCard]}>
+          <View style={styles.amountRow}>
+            <Text style={[styles.amount, isIncome ? styles.amountIncome : styles.amountExpense]}>
+              {amountSign}
+              {transaction.amount.toLocaleString(undefined, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })}
+            </Text>
+            <View
+              style={[
+                styles.typeBadge,
+                isIncome ? styles.typeBadgeIncome : styles.typeBadgeExpense,
+              ]}
+            >
+              <Text style={styles.typeBadgeText}>
+                {isIncome ? "Income" : "Expense"}
+              </Text>
+            </View>
+          </View>
+          <Text style={styles.category}>{transaction.category}</Text>
+          <Text style={styles.date}>{dayjs(transaction.date).format("MMMM D, YYYY")}</Text>
+          {transaction.excludeFromReports && (
+            <View style={styles.excludedPill}>
+              <Ionicons name="shield" size={14} color={theme.colors.textMuted} />
+              <Text style={styles.excludedText}>Excluded from reports</Text>
+            </View>
+          )}
+        </View>
+
+        <View style={[theme.components.surface, styles.sectionCard]}>
+          <Text style={styles.sectionTitle}>Details</Text>
+          <DetailRow label="Note" value={noteDisplay} styles={styles} />
+          <DetailRow
+            label="Type"
+            value={isIncome ? "Income" : "Expense"}
+            styles={styles}
+          />
+          <DetailRow label="Category" value={transaction.category} styles={styles} />
+          <DetailRow
+            label="Date"
+            value={dayjs(transaction.date).format("MMMM D, YYYY")}
+            styles={styles}
+          />
+          {transaction.location ? (
+            <DetailRow label="Location" value={transaction.location} styles={styles} />
+          ) : null}
+          {participants.length ? (
+            <View style={styles.detailGroup}>
+              <Text style={styles.detailLabel}>With</Text>
+              <View style={styles.chipRow}>
+                {participants.map((person) => (
+                  <View key={person} style={styles.chip}>
+                    <Text style={styles.chipText}>{person}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          ) : null}
+          {photos.length ? (
+            <View style={styles.detailGroup}>
+              <Text style={styles.detailLabel}>Photos</Text>
+              <View style={styles.photoGrid}>
+                {photos.map((uri) => (
+                  <Image key={uri} source={{ uri }} style={styles.photo} contentFit="cover" />
+                ))}
+              </View>
+            </View>
+          ) : null}
+        </View>
+      </ScrollView>
+
+      <View style={styles.actionBar}>
+        <Pressable style={styles.actionButton} onPress={handleDuplicate}>
+          <Ionicons name="copy" size={18} color={theme.colors.text} />
+          <Text style={styles.actionButtonText}>Duplicate</Text>
+        </Pressable>
+        <Pressable style={styles.deleteButton} onPress={handleDelete}>
+          <Ionicons name="trash" size={18} color={theme.colors.background} />
+          <Text style={styles.deleteButtonText}>Delete</Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  styles,
+}: {
+  label: string;
+  value: string;
+  styles: ReturnType<typeof createStyles>;
+}) {
+  return (
+    <View style={styles.detailGroup}>
+      <Text style={styles.detailLabel}>{label}</Text>
+      <Text style={styles.detailValue}>{value}</Text>
+    </View>
+  );
+}
+
+const createStyles = (
+  theme: ReturnType<typeof useAppTheme>,
+  insets: ReturnType<typeof useSafeAreaInsets>,
+) =>
+  StyleSheet.create({
+    safeArea: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+    },
+    flex: {
+      flex: 1,
+    },
+    content: {
+      paddingHorizontal: theme.spacing.xl,
+      paddingBottom: theme.spacing.xxl + insets.bottom + 72,
+      gap: theme.spacing.lg,
+    },
+    header: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      paddingTop: theme.spacing.lg,
+      marginBottom: theme.spacing.lg,
+    },
+    headerButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      backgroundColor: theme.colors.surface,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    title: {
+      ...theme.typography.title,
+      fontSize: 22,
+    },
+    summaryCard: {
+      gap: theme.spacing.md,
+      padding: theme.spacing.xl,
+      borderRadius: 18,
+      shadowColor: theme.colors.background,
+      shadowOpacity: 0.12,
+      shadowRadius: 16,
+      shadowOffset: { width: 0, height: 8 },
+    },
+    amountRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+    },
+    amount: {
+      fontSize: 34,
+      fontWeight: "700",
+    },
+    amountIncome: {
+      color: theme.colors.success,
+    },
+    amountExpense: {
+      color: theme.colors.danger,
+    },
+    typeBadge: {
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 6,
+      borderRadius: theme.radii.pill,
+    },
+    typeBadgeIncome: {
+      backgroundColor: `${theme.colors.success}22`,
+    },
+    typeBadgeExpense: {
+      backgroundColor: `${theme.colors.danger}22`,
+    },
+    typeBadgeText: {
+      fontSize: 12,
+      fontWeight: "700",
+      letterSpacing: 1,
+      textTransform: "uppercase",
+      color: theme.colors.text,
+    },
+    category: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: theme.colors.text,
+    },
+    date: {
+      fontSize: 14,
+      color: theme.colors.textMuted,
+    },
+    excludedPill: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      alignSelf: "flex-start",
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 6,
+      borderRadius: theme.radii.pill,
+      backgroundColor: `${theme.colors.textMuted}20`,
+    },
+    excludedText: {
+      fontSize: 12,
+      fontWeight: "600",
+      color: theme.colors.textMuted,
+    },
+    sectionCard: {
+      gap: theme.spacing.lg,
+      padding: theme.spacing.xl,
+      borderRadius: 18,
+    },
+    sectionTitle: {
+      fontSize: 15,
+      fontWeight: "700",
+      color: theme.colors.text,
+      textTransform: "uppercase",
+      letterSpacing: 0.8,
+    },
+    detailGroup: {
+      gap: theme.spacing.xs,
+    },
+    detailLabel: {
+      fontSize: 12,
+      fontWeight: "600",
+      color: theme.colors.textMuted,
+      letterSpacing: 0.6,
+      textTransform: "uppercase",
+    },
+    detailValue: {
+      fontSize: 15,
+      color: theme.colors.text,
+    },
+    chipRow: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      gap: theme.spacing.xs,
+    },
+    chip: {
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: 6,
+      borderRadius: theme.radii.pill,
+      backgroundColor: theme.colors.surface,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+    },
+    chipText: {
+      fontSize: 13,
+      fontWeight: "600",
+      color: theme.colors.text,
+    },
+    photoGrid: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      gap: theme.spacing.sm,
+    },
+    photo: {
+      width: 96,
+      height: 96,
+      borderRadius: theme.radii.md,
+    },
+    actionBar: {
+      position: "absolute",
+      left: theme.spacing.xl,
+      right: theme.spacing.xl,
+      bottom: theme.spacing.xl + insets.bottom,
+      flexDirection: "row",
+      gap: theme.spacing.sm,
+    },
+    actionButton: {
+      flex: 1,
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 8,
+      paddingVertical: 14,
+      borderRadius: theme.radii.md,
+      backgroundColor: theme.colors.surface,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+    },
+    actionButtonText: {
+      fontSize: 15,
+      fontWeight: "600",
+      color: theme.colors.text,
+    },
+    deleteButton: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 8,
+      paddingHorizontal: theme.spacing.lg,
+      borderRadius: theme.radii.md,
+      backgroundColor: theme.colors.danger,
+    },
+    deleteButtonText: {
+      fontSize: 15,
+      fontWeight: "600",
+      color: theme.colors.background,
+    },
+    emptyState: {
+      flex: 1,
+      alignItems: "center",
+      justifyContent: "center",
+      gap: theme.spacing.md,
+      padding: theme.spacing.xl,
+    },
+    emptyTitle: {
+      fontSize: 16,
+      fontWeight: "600",
+      color: theme.colors.text,
+      textAlign: "center",
+    },
+    primaryButton: {
+      ...theme.components.buttonPrimary,
+      paddingHorizontal: theme.spacing.xl,
+    },
+    primaryButtonText: {
+      ...theme.components.buttonPrimaryText,
+    },
+  });

--- a/financetracker/app/transactions/new.tsx
+++ b/financetracker/app/transactions/new.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Alert,
   KeyboardAvoidingView,
@@ -6,56 +6,274 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
+  Switch,
   Text,
   TextInput,
   View,
 } from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
+import { Image } from "expo-image";
+import * as ImagePicker from "expo-image-picker";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
-import { useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import dayjs from "dayjs";
 import { Ionicons } from "@expo/vector-icons";
 
 import { useAppTheme } from "../../theme";
-import { TransactionType, useFinanceStore } from "../../lib/store";
+import { Category, TransactionType, useFinanceStore } from "../../lib/store";
+
+const MAX_NOTE_WORDS = 100;
+
+const getWordCount = (value: string) => {
+  if (!value.trim()) {
+    return 0;
+  }
+  return value.trim().split(/\s+/).filter(Boolean).length;
+};
+
+const ensureDateStartOfDay = (value: Date) => {
+  const next = new Date(value);
+  next.setHours(0, 0, 0, 0);
+  return next;
+};
+
+const renderCategoryGroup = (
+  title: string,
+  items: Category[],
+  activeId: string,
+  onSelect: (categoryId: string) => void,
+  styles: ReturnType<typeof createStyles>,
+) => {
+  if (!items.length) return null;
+
+  return (
+    <View style={styles.categoryGroup}>
+      <Text style={styles.categoryGroupTitle}>{title}</Text>
+      <View style={styles.categoryChips}>
+        {items.map((category) => {
+          const isActive = category.id === activeId;
+          return (
+            <Pressable
+              key={category.id}
+              style={[styles.categoryChip, isActive && styles.categoryChipActive]}
+              onPress={() => onSelect(category.id)}
+            >
+              <Text style={[styles.categoryChipText, isActive && styles.categoryChipTextActive]}>
+                {category.name}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
 
 export default function NewTransactionModal() {
   const theme = useAppTheme();
   const router = useRouter();
+  const params = useLocalSearchParams<{ transactionId?: string }>();
   const addTransaction = useFinanceStore((state) => state.addTransaction);
+  const updateTransaction = useFinanceStore((state) => state.updateTransaction);
+  const transactions = useFinanceStore((state) => state.transactions);
   const currency = useFinanceStore((state) => state.profile.currency);
   const categories = useFinanceStore((state) => state.preferences.categories);
 
-  const [type, setType] = useState<TransactionType>("expense");
   const [amount, setAmount] = useState("");
   const [note, setNote] = useState("");
-  const [category, setCategory] = useState(() => categories[0] ?? "");
-  const [date, setDate] = useState(new Date());
+  const [selectedCategoryId, setSelectedCategoryId] = useState(() => categories[0]?.id ?? "");
+  const [categoryOpen, setCategoryOpen] = useState(false);
+  const [date, setDate] = useState(() => ensureDateStartOfDay(new Date()));
   const [showPicker, setShowPicker] = useState(Platform.OS === "ios");
+  const [showMoreDetails, setShowMoreDetails] = useState(false);
+  const [participants, setParticipants] = useState<string[]>([]);
+  const [participantInput, setParticipantInput] = useState("");
+  const [location, setLocation] = useState("");
+  const [photos, setPhotos] = useState<string[]>([]);
+  const [excludeFromReports, setExcludeFromReports] = useState(false);
+  const [prefilled, setPrefilled] = useState(() => !params.transactionId);
 
   const insets = useSafeAreaInsets();
   const styles = useMemo(() => createStyles(theme, insets), [theme, insets]);
 
+  const selectedCategory = useMemo(
+    () => categories.find((category) => category.id === selectedCategoryId) ?? null,
+    [categories, selectedCategoryId],
+  );
+  const existingTransaction = useMemo(
+    () => transactions.find((transaction) => transaction.id === params.transactionId) ?? null,
+    [transactions, params.transactionId],
+  );
+  const isEditing = Boolean(params.transactionId && existingTransaction);
+  const transactionType: TransactionType = selectedCategory?.type ?? "expense";
+  const noteWordCount = useMemo(() => getWordCount(note), [note]);
+
+  const expenseCategories = useMemo(
+    () => categories.filter((category) => category.type === "expense"),
+    [categories],
+  );
+  const incomeCategories = useMemo(
+    () => categories.filter((category) => category.type === "income"),
+    [categories],
+  );
+
+  const handleCategorySelect = (categoryId: string) => {
+    setSelectedCategoryId(categoryId);
+    setCategoryOpen(false);
+  };
+
+  useEffect(() => {
+    if (!selectedCategory && categories.length) {
+      setSelectedCategoryId(categories[0].id);
+    }
+  }, [categories, selectedCategory]);
+
+  useEffect(() => {
+    if (params.transactionId && !existingTransaction) {
+      Alert.alert("Not found", "We couldn't find that transaction.", [
+        {
+          text: "OK",
+          onPress: () => router.back(),
+        },
+      ]);
+      return;
+    }
+
+    if (isEditing && existingTransaction && !prefilled) {
+      setAmount(existingTransaction.amount.toString());
+      setNote(existingTransaction.note);
+      const matchedCategory = categories.find(
+        (category) => category.name === existingTransaction.category,
+      );
+      setSelectedCategoryId(matchedCategory?.id ?? categories[0]?.id ?? "");
+      setDate(ensureDateStartOfDay(new Date(existingTransaction.date)));
+      setParticipants(existingTransaction.participants ? [...existingTransaction.participants] : []);
+      setLocation(existingTransaction.location ?? "");
+      setPhotos(existingTransaction.photos ? [...existingTransaction.photos] : []);
+      setExcludeFromReports(Boolean(existingTransaction.excludeFromReports));
+      setShowMoreDetails(
+        Boolean(
+          (existingTransaction.participants?.length ?? 0) > 0 ||
+            existingTransaction.location ||
+            (existingTransaction.photos?.length ?? 0) > 0 ||
+            existingTransaction.excludeFromReports,
+        ),
+      );
+      setPrefilled(true);
+    }
+  }, [
+    categories,
+    existingTransaction,
+    isEditing,
+    params.transactionId,
+    prefilled,
+    router,
+  ]);
+
+  const handleNoteChange = (value: string) => {
+    const words = value.match(/\S+/g) ?? [];
+    if (words.length <= MAX_NOTE_WORDS) {
+      setNote(value);
+      return;
+    }
+
+    const truncated = words.slice(0, MAX_NOTE_WORDS).join(" ");
+    setNote(truncated);
+  };
+
+  const handleAddParticipant = () => {
+    const value = participantInput.trim();
+    if (!value) {
+      return;
+    }
+
+    setParticipants((prev) => {
+      if (prev.some((item) => item.toLowerCase() === value.toLowerCase())) {
+        return prev;
+      }
+      return [...prev, value];
+    });
+    setParticipantInput("");
+  };
+
+  const handleRemoveParticipant = (value: string) => {
+    setParticipants((prev) => prev.filter((participant) => participant !== value));
+  };
+
+  const handleAddPhoto = async () => {
+    if (photos.length >= 3) {
+      Alert.alert("Limit reached", "You can attach up to 3 photos per transaction.");
+      return;
+    }
+
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      Alert.alert("Permission needed", "Allow photo library access to attach receipts.");
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+
+    if (!result.canceled && result.assets?.length) {
+      setPhotos((prev) => {
+        const uris = result.assets.map((asset) => asset.uri).filter(Boolean) as string[];
+        const next: string[] = [...prev];
+
+        for (const uri of uris) {
+          if (next.length >= 3) {
+            break;
+          }
+
+          if (!next.includes(uri)) {
+            next.push(uri);
+          }
+        }
+
+        return next;
+      });
+    }
+  };
+
+  const handleRemovePhoto = (uri: string) => {
+    setPhotos((prev) => prev.filter((photo) => photo !== uri));
+  };
+
   const handleSubmit = () => {
-    const parsedAmount = Number(amount);
+    const parsedAmount = Number(amount.replace(/,/g, "."));
 
     if (Number.isNaN(parsedAmount) || parsedAmount <= 0) {
       Alert.alert("Hold up", "Enter a positive amount to continue.");
       return;
     }
 
-    if (!category) {
+    if (!selectedCategory) {
       Alert.alert("Heads up", "Please choose a category for this transaction.");
       return;
     }
 
-    addTransaction({
+    const normalizedDate = ensureDateStartOfDay(date);
+    const finalNote = note.trim();
+
+    const payload = {
       amount: parsedAmount,
-      note: note.trim() || (type === "expense" ? "Expense" : "Income"),
-      category,
-      type,
-      date: date.toISOString(),
-    });
+      note: finalNote,
+      category: selectedCategory.name,
+      type: transactionType,
+      date: normalizedDate.toISOString(),
+      participants,
+      location: location.trim() || undefined,
+      photos,
+      excludeFromReports,
+    };
+
+    if (isEditing && params.transactionId) {
+      updateTransaction(params.transactionId, payload);
+    } else {
+      addTransaction(payload);
+    }
 
     router.back();
   };
@@ -71,7 +289,7 @@ export default function NewTransactionModal() {
           <Pressable onPress={() => router.back()} style={styles.closeButton}>
             <Ionicons name="chevron-down" size={24} color={theme.colors.text} />
           </Pressable>
-          <Text style={styles.title}>Add transaction</Text>
+          <Text style={styles.title}>{isEditing ? "Edit transaction" : "Add transaction"}</Text>
           <View style={{ width: 32 }} />
         </View>
 
@@ -81,21 +299,17 @@ export default function NewTransactionModal() {
           contentInsetAdjustmentBehavior="automatic"
           showsVerticalScrollIndicator={false}
         >
-          <View style={styles.toggleRow}>
-            {["expense", "income"].map((value) => {
-              const isActive = type === value;
-              return (
-                <Pressable
-                  key={value}
-                  onPress={() => setType(value as TransactionType)}
-                  style={[styles.toggleChip, isActive && styles.toggleChipActive]}
-                >
-                  <Text style={[styles.toggleText, isActive && styles.toggleTextActive]}>
-                    {value === "expense" ? "Expense" : "Income"}
-                  </Text>
-                </Pressable>
-              );
-            })}
+          <View
+            style={[
+              styles.typeBadge,
+              transactionType === "income"
+                ? styles.typeBadgeIncome
+                : styles.typeBadgeExpense,
+            ]}
+          >
+            <Text style={styles.typeBadgeText}>
+              {transactionType === "income" ? "Income" : "Expense"} transaction
+            </Text>
           </View>
 
           <View style={styles.fieldGroup}>
@@ -111,36 +325,65 @@ export default function NewTransactionModal() {
           </View>
 
           <View style={styles.fieldGroup}>
-            <Text style={styles.label}>Note</Text>
-            <TextInput
-              value={note}
-              onChangeText={setNote}
-              placeholder="Add a short note"
-              placeholderTextColor={theme.colors.textMuted}
-              style={styles.input}
-            />
+            <Text style={styles.label}>Category</Text>
+            <Pressable
+              style={[styles.input, styles.selectorButton]}
+              onPress={() => setCategoryOpen((prev) => !prev)}
+            >
+              <View style={styles.selectorContent}>
+                <Text style={styles.selectorValue}>
+                  {selectedCategory ? selectedCategory.name : "Choose a category"}
+                </Text>
+                {selectedCategory && (
+                  <Text style={styles.selectorHint}>
+                    {selectedCategory.type === "income" ? "Income" : "Expense"}
+                  </Text>
+                )}
+              </View>
+              <Ionicons
+                name={categoryOpen ? "chevron-up" : "chevron-down"}
+                size={18}
+                color={theme.colors.textMuted}
+              />
+            </Pressable>
+            {categoryOpen && (
+              <View style={styles.categoryList}>
+                {renderCategoryGroup(
+                  "Expenses",
+                  expenseCategories,
+                  selectedCategoryId,
+                  handleCategorySelect,
+                  styles,
+                )}
+                {renderCategoryGroup(
+                  "Income",
+                  incomeCategories,
+                  selectedCategoryId,
+                  handleCategorySelect,
+                  styles,
+                )}
+                {!categories.length && (
+                  <Text style={styles.helperText}>
+                    No categories yet. Add them from Account & preferences.
+                  </Text>
+                )}
+              </View>
+            )}
           </View>
 
           <View style={styles.fieldGroup}>
-            <Text style={styles.label}>Category</Text>
-            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-              <View style={styles.categoryRow}>
-                {categories.map((item) => {
-                  const isActive = category === item;
-                  return (
-                    <Pressable
-                      key={item}
-                      onPress={() => setCategory(item)}
-                      style={[styles.categoryChip, isActive && styles.categoryChipActive]}
-                    >
-                      <Text style={[styles.categoryChipText, isActive && styles.categoryChipTextActive]}>
-                        {item}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
-            </ScrollView>
+            <Text style={styles.label}>Note</Text>
+            <TextInput
+              value={note}
+              onChangeText={handleNoteChange}
+              placeholder="Add a short note"
+              placeholderTextColor={theme.colors.textMuted}
+              style={[styles.input, styles.multilineInput]}
+              multiline
+            />
+            <Text style={styles.wordCounter}>
+              {noteWordCount} / {MAX_NOTE_WORDS} words
+            </Text>
           </View>
 
           <View style={styles.fieldGroup}>
@@ -159,7 +402,7 @@ export default function NewTransactionModal() {
                 display={Platform.OS === "ios" ? "inline" : "default"}
                 onChange={(_, selectedDate) => {
                   if (selectedDate) {
-                    setDate(selectedDate);
+                    setDate(ensureDateStartOfDay(selectedDate));
                   }
                   if (Platform.OS !== "ios") {
                     setShowPicker(false);
@@ -168,10 +411,112 @@ export default function NewTransactionModal() {
               />
             )}
           </View>
+
+          <Pressable
+            style={styles.detailsToggle}
+            onPress={() => setShowMoreDetails((prev) => !prev)}
+          >
+            <Text style={styles.detailsToggleText}>
+              {showMoreDetails ? "Hide additional details" : "Add more details"}
+            </Text>
+            <Ionicons
+              name={showMoreDetails ? "chevron-up" : "chevron-down"}
+              size={18}
+              color={theme.colors.textMuted}
+            />
+          </Pressable>
+
+          {showMoreDetails && (
+            <View style={styles.detailsCard}>
+              <View style={styles.fieldGroup}>
+                <Text style={styles.label}>With</Text>
+                {participants.length > 0 && (
+                  <View style={styles.participantChips}>
+                    {participants.map((person) => (
+                      <View key={person} style={styles.participantChip}>
+                        <Text style={styles.participantChipText}>{person}</Text>
+                        <Pressable
+                          onPress={() => handleRemoveParticipant(person)}
+                          style={styles.participantRemoveButton}
+                        >
+                          <Ionicons name="close" size={12} color={theme.colors.text} />
+                        </Pressable>
+                      </View>
+                    ))}
+                  </View>
+                )}
+                <View style={styles.row}>
+                  <TextInput
+                    value={participantInput}
+                    onChangeText={setParticipantInput}
+                    placeholder="Add a person"
+                    placeholderTextColor={theme.colors.textMuted}
+                    style={[styles.input, styles.flex]}
+                    returnKeyType="done"
+                    onSubmitEditing={handleAddParticipant}
+                  />
+                  <Pressable style={styles.secondaryButton} onPress={handleAddParticipant}>
+                    <Text style={styles.secondaryButtonText}>Add</Text>
+                  </Pressable>
+                </View>
+              </View>
+
+              <View style={styles.fieldGroup}>
+                <Text style={styles.label}>Location</Text>
+                <TextInput
+                  value={location}
+                  onChangeText={setLocation}
+                  placeholder="e.g. Soho Coffee"
+                  placeholderTextColor={theme.colors.textMuted}
+                  style={styles.input}
+                />
+              </View>
+
+              <View style={styles.fieldGroup}>
+                <Text style={styles.label}>Photos</Text>
+                <View style={styles.photoRow}>
+                  {photos.map((uri) => (
+                    <View key={uri} style={styles.photoItem}>
+                      <Image source={{ uri }} style={styles.photoImage} contentFit="cover" />
+                      <Pressable
+                        onPress={() => handleRemovePhoto(uri)}
+                        style={styles.photoRemoveButton}
+                      >
+                        <Ionicons name="close" size={14} color={theme.colors.text} />
+                      </Pressable>
+                    </View>
+                  ))}
+                  {photos.length < 3 && (
+                    <Pressable style={styles.addPhotoButton} onPress={handleAddPhoto}>
+                      <Ionicons name="camera" size={18} color={theme.colors.textMuted} />
+                      <Text style={styles.addPhotoText}>Add photo</Text>
+                    </Pressable>
+                  )}
+                </View>
+              </View>
+
+              <View style={styles.switchRow}>
+                <View>
+                  <Text style={styles.switchLabel}>Exclude from reports</Text>
+                  <Text style={styles.switchHint}>
+                    Keep this transaction out of summaries and insights.
+                  </Text>
+                </View>
+                <Switch
+                  value={excludeFromReports}
+                  onValueChange={setExcludeFromReports}
+                  trackColor={{ true: theme.colors.success, false: theme.colors.border }}
+                  thumbColor={theme.colors.background}
+                />
+              </View>
+            </View>
+          )}
         </ScrollView>
 
         <Pressable style={styles.submitButton} onPress={handleSubmit}>
-          <Text style={styles.submitButtonText}>Add transaction</Text>
+          <Text style={styles.submitButtonText}>
+            {isEditing ? "Save changes" : "Add transaction"}
+          </Text>
         </Pressable>
       </KeyboardAvoidingView>
     </SafeAreaView>
@@ -214,32 +559,8 @@ const createStyles = (
       paddingBottom: theme.spacing.xl + insets.bottom,
       gap: theme.spacing.lg,
     },
-    toggleRow: {
-      flexDirection: "row",
-      gap: theme.spacing.sm,
-    },
-    toggleChip: {
-      paddingHorizontal: theme.spacing.lg,
-      paddingVertical: theme.spacing.sm,
-      borderRadius: theme.radii.pill,
-      borderWidth: 1,
-      borderColor: theme.colors.border,
-    },
-    toggleChipActive: {
-      backgroundColor: theme.colors.primary,
-      borderColor: theme.colors.primary,
-    },
-    toggleText: {
-      fontSize: 14,
-      fontWeight: "600",
-      color: theme.colors.textMuted,
-      textTransform: "capitalize",
-    },
-    toggleTextActive: {
-      color: theme.colors.text,
-    },
     fieldGroup: {
-      gap: theme.spacing.sm,
+      gap: theme.spacing.xs,
     },
     label: {
       ...theme.typography.subtitle,
@@ -250,15 +571,61 @@ const createStyles = (
     input: {
       ...theme.components.input,
       fontSize: 16,
+      minHeight: 48,
     },
-    categoryRow: {
+    multilineInput: {
+      minHeight: 96,
+      textAlignVertical: "top",
+      paddingTop: theme.spacing.sm,
+    },
+    selectorButton: {
       flexDirection: "row",
-      gap: theme.spacing.sm,
+      alignItems: "center",
+      justifyContent: "space-between",
+      paddingRight: theme.spacing.md,
+    },
+    selectorContent: {
+      gap: 2,
+    },
+    selectorValue: {
+      color: theme.colors.text,
+      fontSize: 16,
+      fontWeight: "600",
+    },
+    selectorHint: {
+      fontSize: 12,
+      fontWeight: "600",
+      color: theme.colors.textMuted,
+      textTransform: "uppercase",
+      letterSpacing: 0.8,
+    },
+    categoryList: {
+      ...theme.components.surface,
+      padding: theme.spacing.md,
+      gap: theme.spacing.md,
+    },
+    categoryGroup: {
+      gap: theme.spacing.xs,
+    },
+    categoryGroupTitle: {
+      fontSize: 12,
+      fontWeight: "700",
+      textTransform: "uppercase",
+      letterSpacing: 1.2,
+      color: theme.colors.textMuted,
+    },
+    categoryChips: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      gap: theme.spacing.xs,
     },
     categoryChip: {
-      ...theme.components.chip,
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: theme.spacing.xs,
+      borderRadius: theme.radii.pill,
       borderWidth: 1,
       borderColor: theme.colors.border,
+      backgroundColor: theme.colors.surface,
     },
     categoryChipActive: {
       backgroundColor: theme.colors.primary,
@@ -272,6 +639,16 @@ const createStyles = (
     categoryChipTextActive: {
       color: theme.colors.text,
     },
+    helperText: {
+      fontSize: 12,
+      color: theme.colors.textMuted,
+    },
+    wordCounter: {
+      fontSize: 12,
+      fontWeight: "600",
+      color: theme.colors.textMuted,
+      textAlign: "right",
+    },
     dateButton: {
       flexDirection: "row",
       alignItems: "center",
@@ -282,6 +659,119 @@ const createStyles = (
       fontSize: 16,
       fontWeight: "600",
     },
+    detailsToggle: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      paddingVertical: theme.spacing.xs,
+    },
+    detailsToggleText: {
+      fontSize: 15,
+      fontWeight: "600",
+      color: theme.colors.text,
+    },
+    detailsCard: {
+      ...theme.components.surface,
+      gap: theme.spacing.lg,
+      padding: theme.spacing.lg,
+    },
+    row: {
+      flexDirection: "row",
+      gap: theme.spacing.sm,
+      alignItems: "center",
+    },
+    participantChips: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      gap: theme.spacing.xs,
+    },
+    participantChip: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 4,
+      paddingHorizontal: theme.spacing.sm,
+      paddingVertical: theme.spacing.xs,
+      borderRadius: theme.radii.pill,
+      backgroundColor: theme.colors.surface,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+    },
+    participantChipText: {
+      fontSize: 12,
+      fontWeight: "600",
+      color: theme.colors.text,
+    },
+    participantRemoveButton: {
+      width: 20,
+      height: 20,
+      borderRadius: 10,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: theme.colors.surfaceElevated,
+    },
+    photoRow: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      gap: theme.spacing.sm,
+    },
+    photoItem: {
+      position: "relative",
+      width: 80,
+      height: 80,
+      borderRadius: theme.radii.md,
+      overflow: "hidden",
+      backgroundColor: theme.colors.surfaceElevated,
+    },
+    photoImage: {
+      width: "100%",
+      height: "100%",
+    },
+    photoRemoveButton: {
+      position: "absolute",
+      top: 6,
+      right: 6,
+      width: 24,
+      height: 24,
+      borderRadius: 12,
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: theme.colors.surface,
+      shadowColor: theme.colors.background,
+      shadowOpacity: 0.2,
+      shadowRadius: 4,
+      shadowOffset: { width: 0, height: 2 },
+    },
+    addPhotoButton: {
+      height: 80,
+      paddingHorizontal: theme.spacing.md,
+      borderRadius: theme.radii.md,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      borderStyle: "dashed",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 6,
+    },
+    addPhotoText: {
+      fontSize: 12,
+      fontWeight: "600",
+      color: theme.colors.textMuted,
+    },
+    switchRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: theme.spacing.sm,
+    },
+    switchLabel: {
+      fontSize: 14,
+      fontWeight: "600",
+      color: theme.colors.text,
+    },
+    switchHint: {
+      fontSize: 12,
+      color: theme.colors.textMuted,
+    },
     submitButton: {
       ...theme.components.buttonPrimary,
       marginTop: theme.spacing.lg,
@@ -290,5 +780,37 @@ const createStyles = (
     },
     submitButtonText: {
       ...theme.components.buttonPrimaryText,
+    },
+    secondaryButton: {
+      ...theme.components.buttonSecondary,
+      minWidth: 64,
+      justifyContent: "center",
+      height: 48,
+    },
+    secondaryButtonText: {
+      ...theme.components.buttonSecondaryText,
+    },
+    typeBadge: {
+      alignSelf: "flex-start",
+      paddingHorizontal: theme.spacing.md,
+      paddingVertical: theme.spacing.xs,
+      borderRadius: theme.radii.pill,
+      shadowColor: theme.colors.background,
+      shadowOpacity: 0.12,
+      shadowRadius: 8,
+      shadowOffset: { width: 0, height: 4 },
+    },
+    typeBadgeIncome: {
+      backgroundColor: theme.colors.success,
+    },
+    typeBadgeExpense: {
+      backgroundColor: theme.colors.danger,
+    },
+    typeBadgeText: {
+      fontSize: 12,
+      fontWeight: "700",
+      color: theme.colors.background,
+      textTransform: "uppercase",
+      letterSpacing: 1,
     },
   });

--- a/financetracker/package-lock.json
+++ b/financetracker/package-lock.json
@@ -20,6 +20,7 @@
         "expo-font": "~14.0.8",
         "expo-haptics": "~15.0.7",
         "expo-image": "~3.0.8",
+        "expo-image-picker": "~15.0.7",
         "expo-linking": "~8.0.8",
         "expo-router": "~6.0.8",
         "expo-splash-screen": "~31.0.10",
@@ -6865,6 +6866,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.7.0.tgz",
+      "integrity": "sha512-cx+MxxsAMGl9AiWnQUzrkJMJH4eNOGlu7XkLGnAXSJrRoIiciGaKqzeaD326IyCTV+Z1fXvIliSgNW+DscvD8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-15.0.7.tgz",
+      "integrity": "sha512-u8qiPZNfDb+ap6PJ8pq2iTO7JKX+ikAUQ0K0c7gXGliKLxoXgDdDmXxz9/6QdICTshJBJlBvI0MwY5NWu7A/uw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~4.7.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/financetracker/package.json
+++ b/financetracker/package.json
@@ -11,16 +11,19 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@expo/vector-icons": "^15.0.2",
     "@expo/metro-runtime": "~6.1.2",
+    "@expo/vector-icons": "^15.0.2",
+    "@react-native-community/datetimepicker": "8.4.5",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "dayjs": "^1.11.13",
     "expo": "~54.0.10",
     "expo-constants": "~18.0.9",
     "expo-font": "~14.0.8",
     "expo-haptics": "~15.0.7",
     "expo-image": "~3.0.8",
+    "expo-image-picker": "~15.0.7",
     "expo-linking": "~8.0.8",
     "expo-router": "~6.0.8",
     "expo-splash-screen": "~31.0.10",
@@ -32,21 +35,19 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-web": "~0.21.0",
-    "zustand": "^4.5.4",
-    "dayjs": "^1.11.13",
     "react-native-svg": "15.2.0",
-    "@react-native-community/datetimepicker": "8.4.5"
+    "react-native-web": "~0.21.0",
+    "react-native-worklets": "0.5.1",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
-    "typescript": "~5.9.2",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~10.0.0"
+    "eslint-config-expo": "~10.0.0",
+    "typescript": "~5.9.2"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- allow transactions to keep an empty note and show a category fallback across transaction lists
- display a placeholder on the detail screen when no note is provided
- prevent duplicate photo attachments while respecting the three-photo limit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e35a30dcc48327adaa845f22275001