### PR TITLE
Add recurring option for new transactions and improve category picker

### DIFF
--- a/financetracker/app/transactions/new.tsx
+++ b/financetracker/app/transactions/new.tsx
@@ -6,14 +6,28 @@ import { useFinanceStore } from "../../lib/store";
 export default function NewTransactionModal() {
   const router = useRouter();
   const addTransaction = useFinanceStore((state) => state.addTransaction);
+  const addRecurringTransaction = useFinanceStore(
+    (state) => state.addRecurringTransaction,
+  );
 
   return (
     <TransactionForm
       title="Add transaction"
       submitLabel="Add transaction"
+      allowRecurring
       onCancel={() => router.back()}
-      onSubmit={(transaction) => {
+      onSubmit={(transaction, meta) => {
         addTransaction(transaction);
+        if (meta?.recurring) {
+          addRecurringTransaction({
+            amount: transaction.amount,
+            note: transaction.note,
+            type: transaction.type,
+            category: transaction.category,
+            frequency: meta.recurring.frequency,
+            nextOccurrence: meta.recurring.startDate,
+          });
+        }
         router.back();
       }}
     />

--- a/financetracker/theme.ts
+++ b/financetracker/theme.ts
@@ -112,6 +112,20 @@ const buildComponents = (colors: Colors) => ({
     fontSize: 16,
     fontWeight: "600" as const,
   },
+  buttonSecondary: {
+    backgroundColor: colors.surface,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    paddingVertical: spacing.md,
+    alignItems: "center" as const,
+    justifyContent: "center" as const,
+  },
+  buttonSecondaryText: {
+    color: colors.text,
+    fontSize: 15,
+    fontWeight: "600" as const,
+  },
   input: {
     backgroundColor: colors.surface,
     borderRadius: radii.md,


### PR DESCRIPTION
## Summary
- add an optional recurring toggle to the transaction form with frequency selection and metadata plumbing
- record recurring transactions when the option is enabled on the new transaction screen
- restyle the category picker modal and provide shared secondary button styles so actions remain visible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4814bc26c8327be39fe9a8d8a4df4