### PR TITLE
Add recurring transaction option and default categories

### DIFF
--- a/financetracker/app/transactions/new.tsx
+++ b/financetracker/app/transactions/new.tsx
@@ -6,6 +6,9 @@ import { useFinanceStore } from "../../lib/store";
 export default function NewTransactionModal() {
   const router = useRouter();
   const addTransaction = useFinanceStore((state) => state.addTransaction);
+  const addRecurringTransaction = useFinanceStore(
+    (state) => state.addRecurringTransaction,
+  );
 
   return (
     <TransactionForm
@@ -15,6 +18,18 @@ export default function NewTransactionModal() {
       onSubmit={(transaction) => {
         addTransaction(transaction);
         router.back();
+      }}
+      enableRecurringOption
+      onSubmitRecurring={(transaction, config) => {
+        addRecurringTransaction({
+          amount: transaction.amount,
+          note: transaction.note,
+          type: transaction.type,
+          category: transaction.category,
+          frequency: config.frequency,
+          nextOccurrence: config.startDate,
+          isActive: true,
+        });
       }}
     />
   );

--- a/financetracker/lib/store.ts
+++ b/financetracker/lib/store.ts
@@ -21,6 +21,38 @@ export interface Category {
   type: TransactionType;
 }
 
+export const DEFAULT_CATEGORIES: Category[] = [
+  { id: "cat-food-expense", name: "Food", type: "expense" },
+  { id: "cat-groceries-expense", name: "Groceries", type: "expense" },
+  { id: "cat-dining-expense", name: "Dining", type: "expense" },
+  { id: "cat-lifestyle-expense", name: "Lifestyle", type: "expense" },
+  { id: "cat-fitness-expense", name: "Fitness", type: "expense" },
+  { id: "cat-travel-expense", name: "Travel", type: "expense" },
+  { id: "cat-transport-expense", name: "Transport", type: "expense" },
+  { id: "cat-home-expense", name: "Home", type: "expense" },
+  { id: "cat-bills-expense", name: "Bills", type: "expense" },
+  { id: "cat-gear-expense", name: "Gear", type: "expense" },
+  { id: "cat-creativity-expense", name: "Creativity", type: "expense" },
+  { id: "cat-outdoors-expense", name: "Outdoors", type: "expense" },
+  { id: "cat-work-expense", name: "Work Expenses", type: "expense" },
+  { id: "cat-entertainment-expense", name: "Entertainment", type: "expense" },
+  { id: "cat-pets-expense", name: "Pets", type: "expense" },
+  { id: "cat-family-expense", name: "Family", type: "expense" },
+  { id: "cat-health-expense", name: "Health", type: "expense" },
+  { id: "cat-education-expense", name: "Education", type: "expense" },
+  { id: "cat-utilities-expense", name: "Utilities", type: "expense" },
+  { id: "cat-rent-expense", name: "Rent", type: "expense" },
+  { id: "cat-side-hustle-income", name: "Side Hustle", type: "income" },
+  { id: "cat-client-work-income", name: "Client Work", type: "income" },
+  { id: "cat-salary-income", name: "Salary", type: "income" },
+  { id: "cat-consulting-income", name: "Consulting", type: "income" },
+  { id: "cat-resale-income", name: "Resale", type: "income" },
+  { id: "cat-creative-sales-income", name: "Creative Sales", type: "income" },
+  { id: "cat-investing-income", name: "Investing", type: "income" },
+  { id: "cat-bonus-income", name: "Bonus", type: "income" },
+  { id: "cat-dividends-income", name: "Dividends", type: "income" },
+];
+
 export type ThemeMode = "light" | "dark";
 
 export interface RecurringTransaction {
@@ -440,31 +472,7 @@ export const useFinanceStore = create<FinanceState>((set, get) => ({
   },
   preferences: {
     themeMode: "dark",
-    categories: [
-      { id: "cat-food-expense", name: "Food", type: "expense" },
-      { id: "cat-groceries-expense", name: "Groceries", type: "expense" },
-      { id: "cat-dining-expense", name: "Dining", type: "expense" },
-      { id: "cat-lifestyle-expense", name: "Lifestyle", type: "expense" },
-      { id: "cat-fitness-expense", name: "Fitness", type: "expense" },
-      { id: "cat-travel-expense", name: "Travel", type: "expense" },
-      { id: "cat-transport-expense", name: "Transport", type: "expense" },
-      { id: "cat-home-expense", name: "Home", type: "expense" },
-      { id: "cat-bills-expense", name: "Bills", type: "expense" },
-      { id: "cat-gear-expense", name: "Gear", type: "expense" },
-      { id: "cat-creativity-expense", name: "Creativity", type: "expense" },
-      { id: "cat-outdoors-expense", name: "Outdoors", type: "expense" },
-      { id: "cat-work-expense", name: "Work Expenses", type: "expense" },
-      { id: "cat-entertainment-expense", name: "Entertainment", type: "expense" },
-      { id: "cat-pets-expense", name: "Pets", type: "expense" },
-      { id: "cat-family-expense", name: "Family", type: "expense" },
-      { id: "cat-side-hustle-income", name: "Side Hustle", type: "income" },
-      { id: "cat-client-work-income", name: "Client Work", type: "income" },
-      { id: "cat-salary-income", name: "Salary", type: "income" },
-      { id: "cat-consulting-income", name: "Consulting", type: "income" },
-      { id: "cat-resale-income", name: "Resale", type: "income" },
-      { id: "cat-creative-sales-income", name: "Creative Sales", type: "income" },
-      { id: "cat-investing-income", name: "Investing", type: "income" },
-    ],
+    categories: [...DEFAULT_CATEGORIES],
   },
   transactions: seedTransactions,
   recurringTransactions: [

--- a/financetracker/theme.ts
+++ b/financetracker/theme.ts
@@ -112,6 +112,21 @@ const buildComponents = (colors: Colors) => ({
     fontSize: 16,
     fontWeight: "600" as const,
   },
+  buttonSecondary: {
+    borderRadius: radii.md,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.xl,
+    alignItems: "center" as const,
+    justifyContent: "center" as const,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  buttonSecondaryText: {
+    color: colors.text,
+    fontSize: 16,
+    fontWeight: "600" as const,
+  },
   input: {
     backgroundColor: colors.surface,
     borderRadius: radii.md,


### PR DESCRIPTION
## Summary
- seed the store with a reusable list of default income and expense categories and surface it in the transaction form modal
- add a recurring toggle with frequency controls to the add transaction flow and create recurring entries when enabled
- style secondary buttons for contrast so actions like duplicate remain visible across themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e48b094b10832783ef19d5dcd1ff39