### PR TITLE
Fix transaction editing and search behaviours

### DIFF
--- a/financetracker/app/(tabs)/transactions.tsx
+++ b/financetracker/app/(tabs)/transactions.tsx
@@ -430,14 +430,17 @@ export default function TransactionsScreen() {
     transactions,
   ]);
 
-  const closingBalanceDisplay = useMemo(
-    () =>
-      formatCurrency(summary.closingBalance, currency || "USD", {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      }),
-    [currency, summary.closingBalance],
-  );
+  const closingBalanceDisplay = useMemo(() => {
+    const amount = summary.closingBalance;
+    const hasCents = !Number.isInteger(Math.round(amount * 100) / 100)
+      ? true
+      : !Number.isInteger(amount);
+
+    return formatCurrency(amount, currency || "USD", {
+      minimumFractionDigits: hasCents ? 2 : 0,
+      maximumFractionDigits: 2,
+    });
+  }, [currency, summary.closingBalance]);
 
   const balanceFontSize = useMemo(() => {
     const digitCount = closingBalanceDisplay.replace(/[^0-9]/g, "").length;

--- a/financetracker/components/transactions/TransactionForm.tsx
+++ b/financetracker/components/transactions/TransactionForm.tsx
@@ -50,10 +50,20 @@ type LocaleSeparators = {
 };
 
 const getLocaleSeparators = (): LocaleSeparators => {
-  const parts = new Intl.NumberFormat(undefined).formatToParts(12345.6);
-  const group = parts.find((part) => part.type === "group")?.value ?? ",";
-  const decimal = parts.find((part) => part.type === "decimal")?.value ?? ".";
-  return { decimal, group };
+  const formatter = new Intl.NumberFormat(undefined);
+
+  if (typeof formatter.formatToParts !== "function") {
+    return { decimal: ".", group: "," };
+  }
+
+  try {
+    const parts = formatter.formatToParts(12345.6);
+    const group = parts.find((part) => part.type === "group")?.value ?? ",";
+    const decimal = parts.find((part) => part.type === "decimal")?.value ?? ".";
+    return { decimal, group };
+  } catch {
+    return { decimal: ".", group: "," };
+  }
 };
 
 const formatNumberForInput = (

--- a/financetracker/components/transactions/TransactionForm.tsx
+++ b/financetracker/components/transactions/TransactionForm.tsx
@@ -101,14 +101,19 @@ const formatRawAmountInput = (
     return "";
   }
 
-  const endsWithSeparator = /[.,]$/.test(sanitized);
-  const lastSeparatorIndex = Math.max(sanitized.lastIndexOf("."), sanitized.lastIndexOf(","));
-  let integerPartRaw = sanitized;
+  const endsWithSeparator = /[.,]$/.test(trimmed);
+  const groupingRegex = new RegExp(`\\${separators.group}`, "g");
+  const normalized = sanitized.replace(groupingRegex, "");
+  const lastSeparatorIndex = Math.max(normalized.lastIndexOf("."), normalized.lastIndexOf(","));
+
+  let integerPartRaw = normalized;
   let decimalPartRaw = "";
+  let hasDecimalSeparator = false;
 
   if (lastSeparatorIndex !== -1) {
-    integerPartRaw = sanitized.slice(0, lastSeparatorIndex);
-    decimalPartRaw = sanitized.slice(lastSeparatorIndex + 1).replace(/[^0-9]/g, "");
+    hasDecimalSeparator = true;
+    integerPartRaw = normalized.slice(0, lastSeparatorIndex);
+    decimalPartRaw = normalized.slice(lastSeparatorIndex + 1).replace(/[^0-9]/g, "");
   }
 
   const integerDigits = integerPartRaw.replace(/[^0-9]/g, "");
@@ -127,6 +132,10 @@ const formatRawAmountInput = (
   }
 
   if (endsWithSeparator) {
+    return `${groupedInteger}${separators.decimal}`;
+  }
+
+  if (!hasDecimalSeparator && sanitized.endsWith(separators.group)) {
     return `${groupedInteger}${separators.decimal}`;
   }
 


### PR DESCRIPTION
## Summary
- normalize transaction form amount parsing, allow clearing optional details, and round amounts consistently when storing
- prevent duplicate custom categories created by different casing and trim stored metadata
- update the transactions tab to preserve decimals in currency formatting, expand search coverage, and keep the keyboard hidden until requested

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5d8948f988327b6b2bcde6ca1a620