### PR TITLE
Improve home navigation and transaction summaries

### DIFF
--- a/financetracker/app/(tabs)/home.tsx
+++ b/financetracker/app/(tabs)/home.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import dayjs from "dayjs";
-import { useRouter } from "expo-router";
+import { Link, useRouter } from "expo-router";
 
 import { DonutChart } from "../../components/DonutChart";
 import { SpendingBarChart, SpendingLineChart } from "../../components/SpendingCharts";
@@ -361,16 +361,6 @@ export default function HomeScreen() {
     [transactions],
   );
 
-  const navigateToCategory = useCallback(
-    (category: string) => {
-      router.push({
-        pathname: "/(tabs)/transactions",
-        params: { category },
-      });
-    },
-    [router],
-  );
-
   const trendDelta = previousExpense - periodExpense;
   const spentLess = trendDelta >= 0;
 
@@ -586,19 +576,8 @@ export default function HomeScreen() {
               <View style={styles.topSpendingList}>
                 {topSpendingEntries.map((entry) => {
                   const isCategory = entry.key !== "__others__";
-                  return (
-                    <Pressable
-                      key={entry.key}
-                      onPress={() => isCategory && navigateToCategory(entry.key)}
-                      disabled={!isCategory}
-                      accessibilityRole={isCategory ? "button" : undefined}
-                      accessibilityState={isCategory ? undefined : { disabled: true }}
-                      style={({ pressed }) => [
-                        styles.topSpendingItem,
-                        isCategory && styles.topSpendingItemInteractive,
-                        pressed && isCategory && styles.topSpendingItemPressed,
-                      ]}
-                    >
+                  const content = (
+                    <>
                       <View style={styles.topSpendingItemHeader}>
                         <Text style={styles.topSpendingName}>{entry.label}</Text>
                         <Text style={[styles.topSpendingAmount, styles.topSpendingAmountOffset]}>
@@ -608,7 +587,39 @@ export default function HomeScreen() {
                       <Text style={[styles.spendingPercentage, { color: entry.color }]}>
                         {entry.percentage}% of spend
                       </Text>
-                    </Pressable>
+                    </>
+                  );
+
+                  if (!isCategory) {
+                    return (
+                      <View
+                        key={entry.key}
+                        style={styles.topSpendingItem}
+                        accessibilityRole="text"
+                        accessibilityLabel={`${entry.label}: ${formatCurrency(entry.amount, currency)}, ${entry.percentage}% of spend`}
+                      >
+                        {content}
+                      </View>
+                    );
+                  }
+
+                  return (
+                    <Link
+                      key={entry.key}
+                      href={{ pathname: "/(tabs)/transactions", params: { category: entry.key } }}
+                      asChild
+                    >
+                      <Pressable
+                        accessibilityRole="button"
+                        style={({ pressed }) => [
+                          styles.topSpendingItem,
+                          styles.topSpendingItemInteractive,
+                          pressed && styles.topSpendingItemPressed,
+                        ]}
+                      >
+                        {content}
+                      </Pressable>
+                    </Link>
                   );
                 })}
               </View>

--- a/financetracker/app/(tabs)/leaderboard.tsx
+++ b/financetracker/app/(tabs)/leaderboard.tsx
@@ -6,9 +6,9 @@ import { Ionicons } from "@expo/vector-icons";
 import { useAppTheme } from "../../theme";
 
 const mockLeaders = [
-  { id: "1", name: "Avery Rivera", progress: "Spark Balance +18%" },
-  { id: "2", name: "Noah Kim", progress: "Saved $420 this month" },
-  { id: "3", name: "Zoe Patel", progress: "Debt free streak: 6 weeks" },
+  { id: "1", name: "Alicia Jeanelly", progress: "Spark Balance +18%" },
+  { id: "2", name: "Joshua Wibowo", progress: "Saved $420 this month" },
+  { id: "3", name: "Timothy Gratio", progress: "Debt free streak: 6 weeks" },
 ];
 
 export default function LeaderboardScreen() {

--- a/financetracker/components/SpendingCharts.tsx
+++ b/financetracker/components/SpendingCharts.tsx
@@ -41,7 +41,7 @@ const MIN_CHART_WIDTH = 320;
 const VERTICAL_PADDING = 32;
 const HORIZONTAL_PADDING = 24;
 const GRID_LINE_COUNT = 4;
-const BAR_TOOLTIP_ANCHOR_RATIO = 0.95;
+const BAR_TOOLTIP_ANCHOR_RATIO = 0.99;
 
 const buildPath = (points: { x: number; y: number }[]) => {
   if (!points.length) {

--- a/financetracker/lib/text.ts
+++ b/financetracker/lib/text.ts
@@ -1,0 +1,13 @@
+export const truncateWords = (text: string, limit: number): string => {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  const words = trimmed.split(/\s+/);
+  if (words.length <= limit) {
+    return trimmed;
+  }
+
+  return `${words.slice(0, limit).join(" ")}...`;
+};


### PR DESCRIPTION
## Summary
- add navigation from top spending categories to the transactions tab with tuned visuals and richer recurring details on the home screen
- show recent transactions on the home screen and recurring reminders with category-focused labels and truncated notes
- prioritize category names in the transactions list, respect category deep-links, and reuse shared word truncation logic while refining spending chart tooltips

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5e846cc708327965b8e1c0645fd19